### PR TITLE
Convert 'Stop this script' to 'Stop this block'

### DIFF
--- a/src/objects/Block.tsx
+++ b/src/objects/Block.tsx
@@ -108,6 +108,9 @@ SPECIAL_CASE_ARGS['control_stop'][0] = (arg: Primitive) => {
     if (arg.value === 'other scripts in stage') {
         return new Primitive('other scripts in sprite', true);
     }
+    if (arg.value === 'this script') {
+        return new Primitive('this block', true);
+    }
     return arg;
 };
 


### PR DESCRIPTION
"Stop 'this script'" also affects all custom blocks which it is nested in. This switch is to ensure the functionality is the same.